### PR TITLE
Add instrument names for Nord Drum 2/3

### DIFF
--- a/gui/stepseq.c
+++ b/gui/stepseq.c
@@ -158,6 +158,20 @@ static const char* notename[] = {
 	"C", "Db", "D", "Eb", "E", "F", "Gb", "G", "Ab", "A", "Bb", "B"
 };
 
+/* factory default mappings, nd2 user manual p.10, nd3 user manual p.12 */
+static const char* norddrum[] = {
+	"Channel 1", // 60
+	notename[61%12],
+	"Channel 2",
+	notename[63%12],
+	"Channel 3",
+	"Channel 4",
+	notename[66%12],
+	"Channel 5",
+	notename[68%12],
+	"Channel 6" // 69
+};
+
 ///////////////////////////////////////////////////////////////////////////////
 
 struct MyGimpImage {
@@ -430,6 +444,9 @@ static void set_note_txt (SeqUI* ui, int n) {
 	} else if (dm == 2 && mn >= 36 && mn <= 61) {
 		/* avldrums */
 		robtk_lbl_set_text (ui->lbl_note[n], avldrums[mn-36]);
+	} else if (dm == 3 && mn >= 60 && mn <= 69) {
+		/* nord drum 2 & 3 */
+		robtk_lbl_set_text (ui->lbl_note[n], norddrum[mn-60]);
 	} else {
 		char txt[16];
 		sprintf (txt, "%-2s%d ", notename[mn%12], -1 + mn / 12);
@@ -629,6 +646,7 @@ static RobWidget* toplevel (SeqUI* ui, void* const top) {
 	robtk_select_add_item (ui->sel_drum, 0, "Chromatic");
 	robtk_select_add_item (ui->sel_drum, 1, "GM/GS Drums");
 	robtk_select_add_item (ui->sel_drum, 2, "AVL Drums");
+	robtk_select_add_item (ui->sel_drum, 3, "Nord Drum 2/3");
 	robtk_select_set_default_item (ui->sel_drum, 0);
 	robtk_select_set_callback (ui->sel_drum, cb_drum, ui);
 

--- a/lv2ttl/stepseq.ttl.in
+++ b/lv2ttl/stepseq.ttl.in
@@ -112,6 +112,7 @@
 		lv2:scalePoint [ rdfs:label "Chromatic Scale"; rdf:value 0 ; ] ;
 		lv2:scalePoint [ rdfs:label "GM/GS Drums"; rdf:value 1 ; ] ;
 		lv2:scalePoint [ rdfs:label "AVLinux Drums"; rdf:value 2 ; ] ;
+		lv2:scalePoint [ rdfs:label "Nord Drum 2/3"; rdf:value 3 ; ] ;
 	] , [
 		a lv2:InputPort, lv2:ControlPort;
 		lv2:index 7;


### PR DESCRIPTION
This is exactly how a soft step sequencer should be, great job!

Not sure there is room for a PR like this one but I own a Nord Drum 2 and helps knowing which channel in the machine each stepseq row will trigger (ND has six unnamed channels). Assumes the factory default mappings are being used.

![Screenshot_2020-04-20_00-00-44](https://user-images.githubusercontent.com/930494/79701151-13af0380-829b-11ea-852f-5df4246bf0a5.png)




